### PR TITLE
Make compatible with Particle devices (tested with Photon)

### DIFF
--- a/ChainableLED.cpp
+++ b/ChainableLED.cpp
@@ -86,13 +86,13 @@ void ChainableLED::sendByte(byte b)
 void ChainableLED::sendColor(byte red, byte green, byte blue)
 {
     // Start by sending a byte with the format "1 1 /B7 /B6 /G7 /G6 /R7 /R6"
-    byte prefix = B11000000;
-    if ((blue & 0x80) == 0)     prefix|= B00100000;
-    if ((blue & 0x40) == 0)     prefix|= B00010000; 
-    if ((green & 0x80) == 0)    prefix|= B00001000;
-    if ((green & 0x40) == 0)    prefix|= B00000100;
-    if ((red & 0x80) == 0)      prefix|= B00000010;
-    if ((red & 0x40) == 0)      prefix|= B00000001;
+    byte prefix = 0b11000000;
+    if ((blue & 0x80) == 0)     prefix|= 0b00100000;
+    if ((blue & 0x40) == 0)     prefix|= 0b00010000; 
+    if ((green & 0x80) == 0)    prefix|= 0b00001000;
+    if ((green & 0x40) == 0)    prefix|= 0b00000100;
+    if ((red & 0x80) == 0)      prefix|= 0b00000010;
+    if ((red & 0x40) == 0)      prefix|= 0b00000001;
     sendByte(prefix);
         
     // Now must send the 3 colors

--- a/ChainableLED.h
+++ b/ChainableLED.h
@@ -32,7 +32,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef __ChainableLED_h__
 #define __ChainableLED_h__
 
-#include "Arduino.h"
+#if defined (SPARK)
+  #include "application.h"
+#else
+  #include "Arduino.h"
+#endif
 
 #define _CL_RED             0
 #define _CL_GREEN           1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@ ChainableLED
 ============
 
 Arduino library compatible with Grove Chainable LED and the P9813 chip. It allows controlling a chain of LEDS individually. 
+
 Supports both RGB and HSB color spaces for setting the color of each individual LED.
+
+Compatible with [Particle devices](https://www.particle.io/).
 
 [More information on the wiki](https://github.com/pjpmarques/ChainableLED/wiki)
 


### PR DESCRIPTION
The following pull request makes ChainableLED compatible with Particle devices (http://particle.io/). Tested with Particle Photon + Particle Grove Shield.